### PR TITLE
Volume control fix for MacOS

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -42,6 +42,9 @@ jobs:
           python 
           python -m pip install --upgrade pip
           pip install -r requirements.txt
+      # See https://stackoverflow.com/a/64642492/4654175
+      - name: MacOS fix for puautogui
+        run: python hack/fix_pyautogui_macos.py
       - name: Run PyInstaller
         run: pyinstaller --onedir --additional-hooks-dir extra-hooks --add-data static:static --name remote-play main.py
       - name: Upload artifact

--- a/hack/fix_pyautogui_macos.py
+++ b/hack/fix_pyautogui_macos.py
@@ -47,7 +47,7 @@ def update_code(code, func_name, func_def):
 
 
 # Only applicable for MacOS.
-if sys.platform == "darwin":
+if __name__ == "__main__" and sys.platform == "darwin":
     fpath = os.path.join(os.path.dirname(
         pyautogui.__file__), "_pyautogui_osx.py")
     with open(fpath, 'r+') as file:

--- a/hack/fix_pyautogui_macos.py
+++ b/hack/fix_pyautogui_macos.py
@@ -1,0 +1,61 @@
+# See https://stackoverflow.com/a/64642492/4654175
+# This is run as a part of the package workflow.
+import os
+import pyautogui
+import sys
+
+FUNC_KEYDOWN = """\
+def _keyDown(key):
+    if key.upper() in special_key_translate_table:
+        _specialKeyEvent(key.upper(), 'down')
+    elif key not in keyboardMapping or keyboardMapping[key] is None:
+        return    
+    else:
+        _normalKeyEvent(key, 'down')
+
+"""
+
+FUNC_KEYUP = """\
+def _keyUp(key):
+    if key.upper() in special_key_translate_table:
+        _specialKeyEvent(key.upper(), 'up')
+    elif key not in keyboardMapping or keyboardMapping[key] is None:
+        return
+    else:
+        _normalKeyEvent(key, 'up')
+
+"""
+
+
+def update_code(code, func_name, func_def):
+    # Replace the function with func_name in the code with func_def
+
+    # Make sure that the function exists.
+    start_idx = code.find(f'def {func_name}(')
+    if start_idx < 0:
+        raise AttributeError(f'function {func_name} not found in the file')
+
+    # Get the end of the function based on the file's indentation.
+    end_idx = start_idx
+    while True:
+        nidx = code.find('\n', end_idx)
+        if nidx == -1 or (nidx+1) == len(code) or not code[nidx+1].isspace():
+            break
+        end_idx = nidx+1
+
+    return code[:start_idx] + func_def + code[end_idx:]
+
+
+# Only applicable for MacOS.
+if sys.platform == "darwin":
+    fpath = os.path.join(os.path.dirname(
+        pyautogui.__file__), "_pyautogui_osx.py")
+    with open(fpath, 'r+') as file:
+        contents = file.read()
+        contents = update_code(
+            contents, func_name='_keyDown', func_def=FUNC_KEYDOWN)
+        contents = update_code(
+            contents, func_name='_keyUp', func_def=FUNC_KEYUP)
+        # Overwrite the file
+        file.seek(0)
+        file.write(contents)

--- a/main.py
+++ b/main.py
@@ -20,9 +20,16 @@ def handle_command(cmd):
     elif cmd == "seek_right":
         pyautogui.press("right")
     elif cmd == "volume_up":
-        pyautogui.press("volumeup")
+        # MacOS requires special control for volume
+        if sys.platform == "darwin":
+            pyautogui.press("KEYTYPE_SOUND_UP")
+        else:
+            pyautogui.press("volumeup")
     elif cmd == "volume_down":
-        pyautogui.press("volumedown")
+        if sys.platform == "darwin":
+            pyautogui.press("KEYTYPE_SOUND_DOWN")
+        else:
+            pyautogui.press("volumedown")
 
 
 @app.get("/touchpad/{action}")


### PR DESCRIPTION
Fixes #5 

This PR adds an extra step to the package workflow that runs the python script `fix_pyautogui_macos.py`. We need to do this to fix https://github.com/asweigart/pyautogui/issues/37. The script hotfixes the code changes that need to be done in pyautogui and we are hoping to clean this up as soon as the original issue is resolved.

Also, in `main.py`, press special volume keys if it's MacOS.

Signed-off-by: Shubham Sharma <shubhash@microsoft.com>